### PR TITLE
fix: ensure Excel sample file is created before reading

### DIFF
--- a/MANIPULACAO_DADOS/leitura_excel.py
+++ b/MANIPULACAO_DADOS/leitura_excel.py
@@ -2,10 +2,18 @@
 import os
 import pandas as pd
 
-# Cria um arquivo Excel de exemplo se não existir
-if not os.path.exists('exemplo.xlsx'):
-    df_exemplo = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
-    df_exemplo.to_excel('exemplo.xlsx', index=False)
+# Caminho absoluto para o arquivo Excel no mesmo diretório deste script
+BASE_DIR = os.path.dirname(__file__)
+excel_path = os.path.join(BASE_DIR, 'exemplo.xlsx')
 
-df = pd.read_excel('exemplo.xlsx')
-print(df.head())
+# Cria um arquivo Excel de exemplo se não existir
+if not os.path.exists(excel_path):
+    df_exemplo = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
+    df_exemplo.to_excel(excel_path, index=False)
+
+# Lê o arquivo Excel
+try:
+    df = pd.read_excel(excel_path)
+    print(df.head())
+except FileNotFoundError:
+    print(f"Arquivo não encontrado: {excel_path}")


### PR DESCRIPTION
## Summary
- compute path for `exemplo.xlsx` relative to the script
- create Excel file if missing and handle missing file gracefully

## Testing
- `python MANIPULACAO_DADOS/leitura_excel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8da9460d08322b22a339f922da6d9