### PR TITLE
fix: resolve pylint configuration and style issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-[MASTER]
+[MAIN]
 ignore-patterns=^tests/,.*/__init__\.py,.*\.ipynb
 
 [MESSAGES CONTROL]

--- a/PYTHON_BASICO/estruturas_decisao.py
+++ b/PYTHON_BASICO/estruturas_decisao.py
@@ -1,14 +1,14 @@
 """Exercícios de estruturas de decisão: if, elif, else."""
 # Estruturas de decisão: if, elif, else
-numero = 0
-if numero > 0:
+NUMERO = 0
+if NUMERO > 0:
     print("Positivo")
-elif numero < 0:
+elif NUMERO < 0:
     print("Negativo")
 else:
     print("Zero")
-idade = 18
-if idade >= 16:
+IDADE = 18
+if IDADE >= 16:
     print("Pode votar")
 else:
     print("Não pode votar")

--- a/PYTHON_BASICO/estruturas_repeticao.py
+++ b/PYTHON_BASICO/estruturas_repeticao.py
@@ -2,7 +2,7 @@
 # Estruturas de repetição: for e while
 for i in range(1, 6):
     print(i)
-n = 5
-while n > 0:
-    print(n)
-    n -= 1
+N = 5
+while N > 0:
+    print(N)
+    N -= 1

--- a/PYTHON_BASICO/funcoes.py
+++ b/PYTHON_BASICO/funcoes.py
@@ -1,8 +1,10 @@
 """Exercícios com funções."""
 # Funções
 def quadrado(x):
+    """Return the square of ``x``."""
     return x ** 2
 print(quadrado(4))
 def eh_par(n):
+    """Return ``True`` if ``n`` is even."""
     return n % 2 == 0
 print(eh_par(5))

--- a/PYTHON_BASICO/variaveis_e_tipos.py
+++ b/PYTHON_BASICO/variaveis_e_tipos.py
@@ -1,6 +1,6 @@
 """Exercícios de variáveis, tipos de dados e operações básicas."""
 # Introdução ao Python: Variáveis, tipos de dados e operações básicas
-nome = "SeuNome"
-soma = 5 + 3
-print("Soma:", soma)
-print(type(nome))
+NOME = "SeuNome"
+SOMA = 5 + 3
+print("Soma:", SOMA)
+print(type(NOME))


### PR DESCRIPTION
## Summary
- switch pylintrc to `[MAIN]` section for compatibility
- normalize module-level names and add missing docstrings in basic examples

## Testing
- `pylint $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8db6a4d208322a7bc2892a9e34879